### PR TITLE
Add `dependabot` Configuration for Image's Python Requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/src"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a configuration to have `dependabot` check the Python requirements that are used in the Docker image.

**Note:** I have not bumped the version for this PR because there are no changes to the functionality/implementation for this project. This is only a change for the CI used by this repository.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Currently `dependabot` only checks the Python dependencies in the base directory of the repository. These dependencies are only used for our linting/testing configurations. We also need to keep the dependencies used by the actual Docker image up-to-date in case a vulnerability is discovered in the versions we are using.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I forked the repo and with these changes in place I saw new PRs (https://github.com/mcdonnnj/vdp-scanner-docker/pull/2, https://github.com/mcdonnnj/vdp-scanner-docker/pull/3, https://github.com/mcdonnnj/vdp-scanner-docker/pull/4) generated to update the Python dependencies used by the Docker image.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
