### PR TITLE
Change the author in the image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,12 @@ RUN pipenv sync --clear --verbose
 # python3 package installed in the compile-stage.
 FROM python:3.10.11-alpine3.17 AS build-stage
 
+###
 # For a list of pre-defined annotation keys and value types see:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
+#
 # Note: Additional labels are added by the build workflow.
+###
 LABEL org.opencontainers.image.authors="vm-fusion-dev-group@trio.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@
 # for consistency.
 FROM alpine:3.17 AS compile-stage
 
-# For a list of pre-defined annotation keys and value types see:
-# https://github.com/opencontainers/image-spec/blob/master/annotations.md
-# Note: Additional labels are added by the build workflow.
-LABEL org.opencontainers.image.authors="vm-fusion-dev-group@trio.dhs.gov"
-LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
-
 # Unprivileged user information necessary for the Python virtual environment
 ARG CISA_USER="cisa"
 ENV CISA_HOME="/home/${CISA_USER}"
@@ -59,6 +53,12 @@ RUN pipenv sync --clear --verbose
 # The version of Python used here should match the version of the Alpine
 # python3 package installed in the compile-stage.
 FROM python:3.10.11-alpine3.17 AS build-stage
+
+# For a list of pre-defined annotation keys and value types see:
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+# Note: Additional labels are added by the build workflow.
+LABEL org.opencontainers.image.authors="vm-fusion-dev-group@trio.dhs.gov"
+LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 
 # Unprivileged user information
 ARG CISA_UID=2048

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.17 AS compile-stage
 # For a list of pre-defined annotation keys and value types see:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 # Note: Additional labels are added by the build workflow.
-LABEL org.opencontainers.image.authors="nicholas.mcdonnell@cisa.dhs.gov"
+LABEL org.opencontainers.image.authors="vm-fusion-dev-group@trio.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 
 # Unprivileged user information necessary for the Python virtual environment

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Python library. Then it will output CSVs with agency and domain level results.
 To run the `cisagov/vdp-scanner` image via Docker:
 
 ```console
-docker run cisagov/vdp-scanner:0.2.0-dev.1
+docker run cisagov/vdp-scanner:0.2.0-dev.2
 ```
 
 ### Running with Docker Compose ###
@@ -36,7 +36,7 @@ docker run cisagov/vdp-scanner:0.2.0-dev.1
 
     services:
       vdp-scanner:
-        image: 'cisagov/vdp-scanner:0.2.0-dev.1'
+        image: 'cisagov/vdp-scanner:0.2.0-dev.2'
         volumes:
           - .:/task/host_mount
     ```
@@ -74,7 +74,7 @@ docker run cisagov/vdp-scanner:0.2.0-dev.1
 1. Pull the new image:
 
     ```console
-    docker pull cisagov/vdp-scanner:0.2.0-dev.1
+    docker pull cisagov/vdp-scanner:0.2.0-dev.2
     ```
 
 1. Recreate and run the container by following the [previous instructions](#running-with-docker).
@@ -83,11 +83,11 @@ docker run cisagov/vdp-scanner:0.2.0-dev.1
 
 The images of this container are tagged with
 [semantic versions](https://semver.org).  It is recommended that most users use
-a version tag (e.g. `:0.2.0-dev.1`).
+a version tag (e.g. `:0.2.0-dev.2`).
 
 | Image:tag | Description |
 |-----------|-------------|
-|`cisagov/vdp-scanner:0.2.0-dev.1`| An exact release version. |
+|`cisagov/vdp-scanner:0.2.0-dev.2`| An exact release version. |
 |`cisagov/vdp-scanner:0.2`| The most recent release matching the major and minor version numbers. |
 |`cisagov/vdp-scanner:0`| The most recent release matching the major version number. |
 |`cisagov/vdp-scanner:edge` | The most recent image built from a merge into the `develop` branch of this repository. |
@@ -153,7 +153,7 @@ Build the image locally using this git repository as the [build context](https:/
 
 ```console
 docker build \
-  --tag cisagov/vdp-scanner:0.2.0-dev.1 \
+  --tag cisagov/vdp-scanner:0.2.0-dev.2 \
   https://github.com/cisagov/vdp-scanner-docker.git#develop
 ```
 
@@ -184,7 +184,7 @@ Docker:
       --file Dockerfile-x \
       --platform linux/amd64 \
       --output type=docker \
-      --tag cisagov/vdp-scanner:0.2.0-dev.1 .
+      --tag cisagov/vdp-scanner:0.2.0-dev.2 .
     ```
 
 ## Contributing ##

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.2.0-dev.1"
+__version__ = "0.2.0-dev.2"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the author in the image's labels to the team email instead of an individual team member (me)'s email. It also moves label creation in the Dockerfile to the last stage.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have switched to this approach in the [skeleton](https://github.com/cisagov/skeleton-docker/blob/1f63a5218995bb146a2ff786b96f219b7e16f20a/Dockerfile#L13-L19) and it makes sense to update this image configuration to match. I also noticed that the labels specified in the Dockerfile are not present in the created image if they are not in the last stage of the multi-stage build.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the label improvement like so:

```console
$ docker inspect cisagov/vdp-scanner:0.1.0 | jq '.[] | .Config.Labels'{
  "org.opencontainers.image.created": "2023-03-14T22:06:42Z",
  "org.opencontainers.image.description": "Docker image to run VDP scanning.",
  "org.opencontainers.image.licenses": "CC0-1.0",
  "org.opencontainers.image.revision": "19df96b7675f8d262fa6310997354d89a1224b54",
  "org.opencontainers.image.source": "https://github.com/cisagov/vdp-scanner-docker.git",
  "org.opencontainers.image.title": "vdp-scanner-docker",
  "org.opencontainers.image.url": "https://github.com/cisagov/vdp-scanner-docker",
  "org.opencontainers.image.version": "0.1.0"
}
```

```console
$ docker inspect cisagov/vdp-scanner:improvement-update_image_author | jq '.[] | .Config.Labels'
{
  "org.opencontainers.image.authors": "vm-fusion-dev-group@trio.dhs.gov",
  "org.opencontainers.image.created": "2023-04-12T19:15:58Z",
  "org.opencontainers.image.description": "Docker image to run VDP scanning.",
  "org.opencontainers.image.licenses": "CC0-1.0",
  "org.opencontainers.image.revision": "3546bf88c143752b1936b583a56a1c822c1699bb",
  "org.opencontainers.image.source": "https://github.com/cisagov/vdp-scanner-docker.git",
  "org.opencontainers.image.title": "vdp-scanner-docker",
  "org.opencontainers.image.url": "https://github.com/cisagov/vdp-scanner-docker",
  "org.opencontainers.image.vendor": "Cybersecurity and Infrastructure Security Agency",
  "org.opencontainers.image.version": "0.2.0-dev.2"
}
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
